### PR TITLE
Fix interactive jobs

### DIFF
--- a/src/main/java/org/icatproject/ijp/client/JobOptionsPanel.java
+++ b/src/main/java/org/icatproject/ijp/client/JobOptionsPanel.java
@@ -295,7 +295,7 @@ public class JobOptionsPanel extends VerticalPanel {
 											if (rdpv != null) {
 												JSONObject rdp = rdpv.isObject();
 												String host = rdp.get("host").isString().stringValue();
-												String account = rdp.get("account").isString().stringValue();
+												String account = rdp.get("username").isString().stringValue();
 												String password = rdp.get("password").isString().stringValue();
 												if (Window.Navigator.getPlatform().startsWith("Win")) {
 													portal.datasetsPanel.hostNameField.setValue(host);

--- a/src/main/java/org/icatproject/ijp/server/ejb/session/JobManagementBean.java
+++ b/src/main/java/org/icatproject/ijp/server/ejb/session/JobManagementBean.java
@@ -330,7 +330,10 @@ public class JobManagementBean {
 				.post(Entity.form(f), Response.class);
 
 		checkResponse(response);
-		return response.readEntity(String.class);
+		
+		String s = response.readEntity(String.class);
+		logger.debug("submitInteractive: received response: " + s );
+		return s;
 
 	}
 

--- a/src/main/java/org/icatproject/ijp/server/rest/JobManager.java
+++ b/src/main/java/org/icatproject/ijp/server/rest/JobManager.java
@@ -139,7 +139,7 @@ public class JobManager {
 				JsonObject rdp = jsonReader.readObject().getJsonObject("rdp");
 				if (rdp != null) {
 					String host = rdp.getString("host");
-					String account = rdp.getString("account");
+					String account = rdp.getString("username");
 					String password = rdp.getString("password");
 					return "rdesktop -u " + account + " -p " + password + " " + host;
 				} else {


### PR DESCRIPTION
Launch of interactive jobs was failing silently from the portal GUI (no window alerts, no log messages). Using the command-line client "ijp" revealed that there was a disagreement about the expected JSON fields in the rdp object: ijp.batch.BatchJson used "username", but ijp.server expected "account". I chose "username" as it seems the more precise property.

With this change, I am able to launch simple "xterm" interactive jobs.

I have tested this on the cloud VMs (vm31 / vm26), and installed it on rclsfserv010.rc-harwell.ac.uk.

Brian