### PR TITLE
Fix status 500

### DIFF
--- a/src/main/java/org/icatproject/ijp/server/ejb/session/JobManagementBean.java
+++ b/src/main/java/org/icatproject/ijp/server/ejb/session/JobManagementBean.java
@@ -460,7 +460,7 @@ public class JobManagementBean {
 			checkResponse(response);
 			String json = response.readEntity(String.class);
 			try (JsonReader jsonReader = Json.createReader(new StringReader(json))) {
-				status = jsonReader.readObject().getString("Status");
+				status = jsonReader.readObject().getString("status");
 				if (status.equals("Completed")) {
 					job.setStatus(Status.COMPLETED);
 				} else if (status.equals("Cancelled")) {


### PR DESCRIPTION
The ijp[batch] script was reporting a status 500 response error on some status requests. I discovered that ijp.server's JobManagementBean's getStatus method was expecting a JSON object from the batch connector with a field "Status" instead of "status"; changing this has solved the issue.
