### PR TITLE
add config for multiple dataset handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,27 +149,6 @@
 			</plugin>
 
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>gwt-maven-plugin</artifactId>
-				<version>${gwt.version}</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-							<!-- goal>test</goal -->
-							<!-- goal>generateAsync</goal -->
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<runTarget>portal/index.html</runTarget>
-					<hostedWebapp>${webappDirectory}</hostedWebapp>
-					<style>PRETTY</style> <!-- set to OBFUSTICATED for production -->
-					<strict>true</strict>
-				</configuration>
-			</plugin>
-
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
 				<version>2.3</version>

--- a/src/main/java/org/icatproject/ijp/client/DatasetsPanel.java
+++ b/src/main/java/org/icatproject/ijp/client/DatasetsPanel.java
@@ -468,7 +468,7 @@ public class DatasetsPanel extends Composite implements RequiresResize {
 				selectedDatasets.addAll(selectionModel.getSelectedSet());
 				// Don't forget to clear the selectedDatafiles!
 				selectedDatafiles.clear();
-				if (selectedDatasets.size() > 1 && !jobType.getMultiple()
+				if (selectedDatasets.size() > 1 && !jobType.getMultiple().isMultiple()
 						&& jobType.getType().equalsIgnoreCase("INTERACTIVE")) {
 					Window.alert("'" + jobName + "' does not allow multiple datasets to be selected");
 				} else {
@@ -523,7 +523,7 @@ public class DatasetsPanel extends Composite implements RequiresResize {
 				for( SelectionListContent item : datasetsCartPanel.getEverything() ){
 					selectedDatasets.add( ((DatasetListContent)item).getDatasetOverview() );
 				}
-				if (selectedDatasets.size() > 1 && !jobType.getMultiple()
+				if (selectedDatasets.size() > 1 && !jobType.getMultiple().isMultiple()
 						&& jobType.getType().equalsIgnoreCase("INTERACTIVE")) {
 					Window.alert("'" + jobName + "' does not allow multiple datasets to be selected");
 				} else {
@@ -558,7 +558,7 @@ public class DatasetsPanel extends Composite implements RequiresResize {
 				for( SelectionListContent item : datafilesCartPanel.getEverything() ){
 					selectedDatafiles.add( (DatafileOverview)item );
 				}
-				if (selectedDatafiles.size() > 1 && !jobType.getMultiple()
+				if (selectedDatafiles.size() > 1 && !jobType.getMultiple().isMultiple()
 						&& jobType.getType().equalsIgnoreCase("INTERACTIVE")) {
 					Window.alert("'" + jobName + "' does not allow multiple datafiles to be selected");
 				} else {
@@ -593,7 +593,7 @@ public class DatasetsPanel extends Composite implements RequiresResize {
 				for( SelectionListContent item : datafilesCartPanel.getEverything() ){
 					selectedDatafiles.add( (DatafileOverview)item );
 				}
-				if (selectedDatafiles.size() + selectedDatasets.size() > 1 && !jobType.getMultiple()
+				if (selectedDatafiles.size() + selectedDatasets.size() > 1 && !jobType.getMultiple().isMultiple()
 						&& jobType.getType().equalsIgnoreCase("INTERACTIVE")) {
 					Window.alert("'" + jobName + "' does not allow multiple datasets/datafiles to be selected");
 				} else {
@@ -785,7 +785,7 @@ public class DatasetsPanel extends Composite implements RequiresResize {
 		} else {
 			String joiner;
 			String plurality;
-			if( jobType.getMultiple() ){
+			if( jobType.getMultiple().isMultiple() ){
 				details = "runs for multiple ";
 				joiner = " and ";
 				plurality = "s";

--- a/src/main/java/org/icatproject/ijp/client/JobOptionsPanel.java
+++ b/src/main/java/org/icatproject/ijp/client/JobOptionsPanel.java
@@ -107,7 +107,7 @@ public class JobOptionsPanel extends VerticalPanel {
 					if (jobType.getType().equalsIgnoreCase("interactive")) {
 						multiJobType = MultiJobTypes.MULTIPLE_DATASETS_ONE_JOB;
 					} else if (jobType.getType().equalsIgnoreCase("batch")) {
-						if (jobType.getMultiple() == false) {
+						if (jobType.getMultiple().isMultiple() == false) {
 							if (confirmMultipleCheckBox.getValue() == false) {
 								formErrors
 										.add("Please tick the box at the top of the form to confirm your intention to run multiple jobs");
@@ -571,7 +571,7 @@ public class JobOptionsPanel extends VerticalPanel {
 						int numSelectedSetsOrFiles = numSelectedDatasets + numSelectedDatafiles;
 						if (jobType.getType().equalsIgnoreCase("batch") && numSelectedSetsOrFiles > 1) {
 							HorizontalPanel warningPanel = new HorizontalPanel();
-							if (jobType.getMultiple() == false) {
+							if (jobType.getMultiple().isMultiple() == false) {
 								// warn user that they are submitting multiple
 								// jobs
 								// get them to tick a checkbox to confirm

--- a/src/main/java/org/icatproject/ijp/server/ejb/session/JobManagementBean.java
+++ b/src/main/java/org/icatproject/ijp/server/ejb/session/JobManagementBean.java
@@ -677,7 +677,8 @@ public class JobManagementBean {
 		JsonGenerator gen = Json.createGenerator(baos).writeStartObject();
 			gen.write("name",jt.getName());
 			gen.write("executable",jt.getExecutable());
-			gen.write("multiple",jt.getMultiple());
+			gen.write("multiple",jt.getMultiple().isMultiple());
+			gen.write("forceSingleJob", jt.getMultiple().isForceSingleJob());
 			gen.write("type",jt.getType());
 			writeIfNotNull(gen,"family",jt.getFamily());
 			writeIfNotNull(gen,"acceptsDatasets",jt.isAcceptsDatasets());

--- a/src/main/java/org/icatproject/ijp/server/manager/XmlFileManager.java
+++ b/src/main/java/org/icatproject/ijp/server/manager/XmlFileManager.java
@@ -67,7 +67,7 @@ public class XmlFileManager {
 		return jobTypeMappings;
 	}
 
-	private JobType getJobType(File xmlFile) throws InternalException {
+	public JobType getJobType(File xmlFile) throws InternalException {
 		JobType jobType = null;
 		try {
 			JAXBContext context = JAXBContext.newInstance(JobType.class);

--- a/src/main/java/org/icatproject/ijp/shared/xmlmodel/JobType.java
+++ b/src/main/java/org/icatproject/ijp/shared/xmlmodel/JobType.java
@@ -14,7 +14,6 @@ public class JobType implements IsSerializable {
 
 	private String name;
 	private String executable;
-	private boolean multiple;
 	private String type;
 
 	@XmlAttribute
@@ -33,6 +32,8 @@ public class JobType implements IsSerializable {
 	private List<String> datasetTypes = new ArrayList<String>();
 	@XmlElement
 	private List<JobOption> jobOptions = new ArrayList<JobOption>();
+
+	private MultipleOptions multiple = new MultipleOptions();
 
 	public JobType() {
 
@@ -69,12 +70,14 @@ public class JobType implements IsSerializable {
 		this.executable = executable;
 	}
 
-	public boolean getMultiple() {
+	public MultipleOptions getMultiple() {
+		if(multiple == null)
+			return new MultipleOptions();
 		return multiple;
 	}
 
-	public void setMultiple(boolean multiple) {
-		this.multiple = multiple;
+	public void setMultiple(MultipleOptions multipleOptions) {
+		this.multiple = multipleOptions;
 	}
 
 	public String getType() {

--- a/src/main/java/org/icatproject/ijp/shared/xmlmodel/MultipleOptions.java
+++ b/src/main/java/org/icatproject/ijp/shared/xmlmodel/MultipleOptions.java
@@ -1,0 +1,34 @@
+package org.icatproject.ijp.shared.xmlmodel;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlValue;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class MultipleOptions {
+    @XmlValue
+    private boolean multiple = false;
+
+    @XmlAttribute
+    private boolean forceSingleJob = false;
+
+    public MultipleOptions() {
+    }
+
+    public boolean isMultiple() {
+        return multiple;
+    }
+
+    public void setMultiple(boolean multiple) {
+        this.multiple = multiple;
+    }
+
+    public boolean isForceSingleJob() {
+        return forceSingleJob;
+    }
+
+    public void setForceSingleJob(boolean forceSingleJob) {
+        this.forceSingleJob = forceSingleJob;
+    }
+}

--- a/src/main/webapp/portal.html
+++ b/src/main/webapp/portal.html
@@ -1,42 +1,8 @@
 <!doctype html>
-<!-- The DOCTYPE declaration above will set the     -->
-<!-- browser's rendering engine into                -->
-<!-- "Standards Mode". Replacing this declaration   -->
-<!-- with a "Quirks Mode" doctype is not supported. -->
-
 <html>
-<head>
-<meta http-equiv="X-UA-Compatible" content="IE=9">
-<meta http-equiv="content-type" content="text/html; charset=UTF-8">
-
-<title>ICAT Job Portal</title>
-
-<!--                                           -->
-<!-- This script loads your compiled module.   -->
-<!-- If you add any GWT meta tags, they must   -->
-<!-- be added before this line.                -->
-<!--                                           -->
-<script type="text/javascript" src="portal/portal.nocache.js"></script>
-</head>
-
-<!--                                           -->
-<!-- The body can have arbitrary html, or      -->
-<!-- you can leave the body empty if you want  -->
-<!-- to create a completely dynamic UI.        -->
-<!--                                           -->
+<head></head>
 <body>
-
-	<!-- OPTIONAL: include this if you want history support -->
-	<iframe src="javascript:''" id="__gwt_historyFrame" tabIndex='-1'
-		style="position: absolute; width: 0; height: 0; border: 0"></iframe>
-
-	<!-- RECOMMENDED if your web app will not function without JavaScript enabled -->
-	<noscript>
-		<div
-			style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
-			Your web browser must have JavaScript enabled in order for this
-			application to display correctly.</div>
-	</noscript>
+Certificate accepted. You can now visit the main topcat site.
 
 </body>
 </html>

--- a/src/test/java/org/icatproject/ijp/server/manager/XmlFileManagerTest.java
+++ b/src/test/java/org/icatproject/ijp/server/manager/XmlFileManagerTest.java
@@ -1,0 +1,129 @@
+package org.icatproject.ijp.server.manager;
+
+import org.icatproject.ijp.shared.InternalException;
+import org.icatproject.ijp.shared.xmlmodel.JobType;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class XmlFileManagerTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testJobTypeModel_multipleTrue_multipleTrue() throws IOException, InternalException {
+        File input = folder.newFile("test.xml");
+
+        try(PrintWriter writer = new PrintWriter(input)) {
+            writer.write("<jobType>\n" +
+                    "    <multiple>true</multiple>\n" +
+                    "</jobType>");
+        };
+
+
+        XmlFileManager fileManager = new XmlFileManager();
+
+        JobType jt = fileManager.getJobType(input);
+
+        assertThat(jt.getMultiple().isMultiple(), equalTo(true));
+    }
+
+    @Test
+    public void testJobTypeModel_multipleFalse_multipleFalse() throws IOException, InternalException {
+        File input = folder.newFile("test.xml");
+
+        try(PrintWriter writer = new PrintWriter(input)) {
+            writer.write("<jobType>\n" +
+                    "    <multiple>false</multiple>\n" +
+                    "</jobType>");
+        };
+
+
+        XmlFileManager fileManager = new XmlFileManager();
+
+        JobType jt = fileManager.getJobType(input);
+
+        assertThat(jt.getMultiple().isMultiple(), equalTo(false));
+    }
+
+    @Test
+    public void testJobTypeModel_noMultipleEntry_multipleFalse() throws IOException, InternalException {
+        File input = folder.newFile("test.xml");
+
+        try(PrintWriter writer = new PrintWriter(input)) {
+            writer.write("<jobType>\n" +
+                    "</jobType>");
+        };
+
+
+        XmlFileManager fileManager = new XmlFileManager();
+
+        JobType jt = fileManager.getJobType(input);
+
+        assertThat(jt.getMultiple().isMultiple(), equalTo(false));
+    }
+
+    @Test
+    public void testJobTypeModel_forceSingleJob_forceSingleJobIsTrue() throws IOException, InternalException {
+        File input = folder.newFile("test.xml");
+
+        try(PrintWriter writer = new PrintWriter(input)) {
+            writer.write("<jobType>\n" +
+                    "    <multiple forceSingleJob=\"true\">true</multiple>\n" +
+                    "</jobType>");
+        };
+
+
+        XmlFileManager fileManager = new XmlFileManager();
+
+        JobType jt = fileManager.getJobType(input);
+
+        assertThat(jt.getMultiple().isForceSingleJob(), equalTo(true));
+    }
+
+    @Test
+    public void testJobTypeModel_noForceSingleJobAttribute_forceSingleJobIsFalse() throws IOException,
+            InternalException {
+        File input = folder.newFile("test.xml");
+
+        try(PrintWriter writer = new PrintWriter(input)) {
+            writer.write("<jobType>\n" +
+                    "    <multiple>true</multiple>\n" +
+                    "</jobType>");
+        };
+
+
+        XmlFileManager fileManager = new XmlFileManager();
+
+        JobType jt = fileManager.getJobType(input);
+
+        assertThat(jt.getMultiple().isForceSingleJob(), equalTo(false));
+    }
+
+    @Test
+    public void testJobTypeModel_forceSingleJobAttributeIsFalse_forceSingleJobIsFalse() throws IOException,
+            InternalException {
+        File input = folder.newFile("test.xml");
+
+        try(PrintWriter writer = new PrintWriter(input)) {
+            writer.write("<jobType>\n" +
+                    "    <multiple forceSingleJob=\"false\">true</multiple>\n" +
+                    "</jobType>");
+        };
+
+
+        XmlFileManager fileManager = new XmlFileManager();
+
+        JobType jt = fileManager.getJobType(input);
+
+        assertThat(jt.getMultiple().isForceSingleJob(), equalTo(false));
+    }
+}


### PR DESCRIPTION
1. if the jobtype xml has <multiple>true</multiple> then the user is given the option to run it as many jobs or as a single job
2. if the jobtype xml has <multiple forceSingleJob="true">true</multiple> then the user is not given the option and must run it as a single job
3. if the jobtype xml has <multiple>false</multiple> or no <multiple> tag then the user is not given the option and must run it multiple jobs

example job types for 1. and 2. exist icatproject/ijp.demo#7

closes #48 