### PR TITLE
Add new JobType Applications to ICAT

### DIFF
--- a/src/main/config/ijp.example/ijp.properties
+++ b/src/main/config/ijp.example/ijp.properties
@@ -4,6 +4,15 @@ ijp.url = https://smfisher.esc.rl.ac.uk:8181
 
 reader = db username root password password
 
+# writer may be used to create Applications in ICAT,
+# so must be able to do so.
+writer = db username root password password
+
+# List of Facility names that may be used by jobs
+# Note: comma-separated, leading/trailing spaces insignificant
+# Unrecognised names will be ignored
+facilities = LSF, TestFacility
+
 batchserverUrls = https://smfisher.esc.rl.ac.uk:8181
 
 # authn methods

--- a/src/site/xdoc/installation.xml.vm
+++ b/src/site/xdoc/installation.xml.vm
@@ -59,7 +59,7 @@
                         Please follow
                         <a href="http://icatproject.org/installation/component/"> the generic installation instructions</a>
                     </li>
-                    <li> Update the ijp.properties file with the ICAT and IDS urls, and URLs of the IJP batch servers.</li>
+                    <li> Update the ijp.properties file with the ICAT, IDS and IJP urls, and URLs of the IJP batch servers.</li>
                     <li>The glassfish certificate for the central IJP server may need to be added to the Java trust store
                       and to the glassfish keystore on each batch server.  See the 
                       <a href="http://icatproject.org/installation/glassfish/">Glassfish installation instructions</a>
@@ -123,6 +123,11 @@
                         e.g. https://sig-23.esc.rl.ac.uk:8181.
                     </dd>
                     
+                    <dt>ijp.url</dt>
+                    <dd>The (prefix of the) URL for the IJP instance itself (to be passed to jobs that create provenance),
+                        e.g. https://sig-23.esc.rl.ac.uk:8181.
+                    </dd>
+                    
                     <dt>batchserverUrls</dt>
                     <dd>List of (prefixes of) URLs for IJP batch servers to which the IJP can submit jobs,
                         e.g. https://sig-23.esc.rl.ac.uk:8181,https://ijp.scarf.rl.ac.uk:8181
@@ -131,6 +136,18 @@
                     <dt>reader</dt>
                     <dd>Authentication details for an ICAT account used by the IJP to login to ICAT,
                         e.g. "simple username br54 password secret"
+                    </dd>
+                    
+                    <dt>writer</dt>
+                    <dd>Authentication details for an ICAT account used by the IJP to login to ICAT and which
+                        may be used to change ICAT (specifically, to add Applications for job types if required);
+                        e.g. "simple username br54 password secret"
+                    </dd>
+                    
+                    <dt>facilities</dt>
+                    <dd>A comma-separated list of names of Facilities that may be used by jobs
+                        e.g. "LSF, Test Facility". Facility names may include spaces, but leading/trailing
+                        spaces will be removed.
                     </dd>
                     
                     <dt>authn.list</dt>

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -6,6 +6,12 @@
     </properties>
 
     <body>
+        <section name="2.0.2">
+            <ul>
+                <li>Link job provenance to job that created it, and display provenance details in the GUI</li>
+                <li>Check that each job type has a corresponding ICAT Application in each Facility, creating it if necessary</li>
+            </ul>
+        </section>
         <section name="2.0.0">
             <p>Initial release - this is the first properly tagged release</p>
         </section>


### PR DESCRIPTION
Fixes #51
During processing of JobTypes, check that for each JobType there is an
Application in each Facility (as named in new ijp.property 'facilities')
with the same name (and version 1.0). If it is not found, add it.
Updated sample ijp.properties file, installation and release notes to
match.