### PR TITLE
Make provenance options optional

### DIFF
--- a/src/main/java/org/icatproject/ijp/shared/xmlmodel/JobType.java
+++ b/src/main/java/org/icatproject/ijp/shared/xmlmodel/JobType.java
@@ -28,6 +28,8 @@ public class JobType implements IsSerializable {
 	private boolean acceptsDatasets;
 	@XmlAttribute
 	private boolean acceptsDatafiles;
+	@XmlAttribute
+	private boolean createsProvenance;
 	@XmlElement
 	private List<String> datasetTypes = new ArrayList<String>();
 	@XmlElement
@@ -118,6 +120,10 @@ public class JobType implements IsSerializable {
 
 	public boolean isAcceptsDatafiles(){
 		return acceptsDatafiles;
+	}
+
+	public boolean createsProvenance(){
+		return createsProvenance;
 	}
 
 }


### PR DESCRIPTION
Added new createsProvenance boolean attribute to the JobType XML;
modified JobManagementBean so that the ijpUrl and ijpJobId parameters
are only set for jobtypes with createsProvenance true. In addition, when
jobtypes are processed, only check for corresponding Applications in
ICAT for jobtypes that have createsProvenance true.

Fixes #50
TG-14 #ready-for-test-deployment
TG-21 #ready-for-test-deployment